### PR TITLE
Allow region to be specified on stack deletion

### DIFF
--- a/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormationNotifier.java
+++ b/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormationNotifier.java
@@ -68,8 +68,8 @@ public class CloudFormationNotifier extends Notifier {
 					"",
 					new HashMap<String, String>(),
 					0,
-					stack.getAwsAccessKey(),
-					stack.getAwsSecretKey(),
+					stack.getParsedAwsAccessKey(envVars),
+					stack.getParsedAwsSecretKey(envVars),
 					false,
 					envVars
 			);

--- a/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormationNotifier.java
+++ b/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormationNotifier.java
@@ -70,7 +70,7 @@ public class CloudFormationNotifier extends Notifier {
 					0,
 					stack.getParsedAwsAccessKey(envVars),
 					stack.getParsedAwsSecretKey(envVars),
-					null,
+					stack.getParsedAwsRegion(envVars),
 					false,
 					envVars
 			);

--- a/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/SimpleStackBean.java
+++ b/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/SimpleStackBean.java
@@ -33,12 +33,18 @@ public class SimpleStackBean extends AbstractDescribableImpl<SimpleStackBean> {
 	 * The secret key to call Amazon's APIs
 	 */
 	private String awsSecretKey;
+	
+	/**
+	 * The AWS region containing the stack.
+	 */
+	private String awsRegion;
 
 	@DataBoundConstructor
-	public SimpleStackBean(String stackName, String awsAccessKey, String awsSecretKey) {
+	public SimpleStackBean(String stackName, String awsAccessKey, String awsSecretKey, String awsRegion) {
 		this.stackName = stackName;
 		this.awsAccessKey = awsAccessKey;
 		this.awsSecretKey = awsSecretKey;
+		this.awsRegion = awsRegion;
 	}
 
 	public String getStackName() {
@@ -53,13 +59,20 @@ public class SimpleStackBean extends AbstractDescribableImpl<SimpleStackBean> {
 		return awsSecretKey;
 	}
 
+	public String getAwsRegion() {
+		return awsRegion;
+	}
+
 	public String getParsedAwsAccessKey(EnvVars env) {
 		return env.expand(getAwsAccessKey());
 	}
 
-
 	public String getParsedAwsSecretKey(EnvVars env) {
 		return env.expand(getAwsSecretKey());
+	}
+
+	public String getParsedAwsRegion(EnvVars env) {
+		return env.expand(getAwsRegion());
 	}
 
 	@Extension

--- a/src/main/resources/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/SimpleStackBean/config.jelly
+++ b/src/main/resources/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/SimpleStackBean/config.jelly
@@ -11,6 +11,9 @@
 		<f:entry title="AWS Secret Key" field="awsSecretKey">
 			<f:password />
 		</f:entry>
+		<f:entry title="AWS Region" field="awsRegion">
+			<f:textbox />
+		</f:entry>
 		<f:entry>
 			<f:repeatableDeleteButton />
 		</f:entry>

--- a/src/main/resources/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/SimpleStackBean/help-awsRegion.html
+++ b/src/main/resources/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/SimpleStackBean/help-awsRegion.html
@@ -1,0 +1,3 @@
+<div>
+	<p>Name of the region to delete stack from. The name must be the identifier of the region within AWS (us-east-1). It defaults to the default AWS Region if not set, which should be us-east-1.</p>
+</div>


### PR DESCRIPTION
This commit adds the ability to specify the region when deleting a stack.

I've also merged in a commit from upstream, to allow the access/secret keys for deleting stacks to be specified via environment variables.
